### PR TITLE
MMCA - 4030 Issue: Validation does not accommodate spaces #5203

### DIFF
--- a/app/uk/gov/hmrc/customs/emailfrontend/forms/Forms.scala
+++ b/app/uk/gov/hmrc/customs/emailfrontend/forms/Forms.scala
@@ -18,12 +18,14 @@ package uk.gov.hmrc.customs.emailfrontend.forms
 
 import play.api.data.Form
 import play.api.data.Forms._
-import uk.gov.hmrc.customs.emailfrontend.forms.Validation.{validVerifyChange, _}
+import uk.gov.hmrc.customs.emailfrontend.Utils.stripWhiteSpaces
+import uk.gov.hmrc.customs.emailfrontend.forms.Validation._
 import uk.gov.hmrc.customs.emailfrontend.model.{Email, VerifyChange, YesNo}
 
 object Forms {
 
-  val emailForm: Form[Email] = Form(mapping("email" -> text.verifying(validEmail))(Email.apply)(Email.unapply))
+  val emailForm: Form[Email] = Form(mapping("email" -> text.verifying(validEmail).transform(
+    stripWhiteSpaces, identity[String]))(Email.apply)(Email.unapply))
 
   val confirmEmailForm: Form[YesNo] = Form(
     mapping(

--- a/app/uk/gov/hmrc/customs/emailfrontend/forms/Validation.scala
+++ b/app/uk/gov/hmrc/customs/emailfrontend/forms/Validation.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.customs.emailfrontend.forms
 
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
-import uk.gov.hmrc.emailaddress.EmailAddress
+import uk.gov.hmrc.customs.emailfrontend.Utils.stripWhiteSpaces
 
 object Validation {
 
@@ -25,11 +25,11 @@ object Validation {
 
   def validEmail: Constraint[String] =
     Constraint({
-      case e if e.trim.isEmpty =>
+      case e if stripWhiteSpaces(e).isEmpty =>
         Invalid(ValidationError("customs.emailfrontend.errors.valid-email.empty"))
       case e if e.length > 50 =>
         Invalid(ValidationError("customs.emailfrontend.errors.valid-email.too-long"))
-      case e if !isValid(e) =>
+      case e if !isValid(stripWhiteSpaces(e)) =>
         Invalid(ValidationError("customs.emailfrontend.errors.valid-email.wrong-format"))
       case _ => Valid
     })

--- a/app/uk/gov/hmrc/customs/emailfrontend/package.scala
+++ b/app/uk/gov/hmrc/customs/emailfrontend/package.scala
@@ -52,4 +52,10 @@ package object emailfrontend {
         Retrieve(r, c)
     }
   }
+
+  object Utils {
+    val emptyString = ""
+
+    def stripWhiteSpaces(str: String): String = str.trim.replaceAll("\\s", emptyString)
+  }
 }

--- a/test/uk/gov/hmrc/customs/emailfrontend/PackageSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/PackageSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.emailfrontend
+
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import uk.gov.hmrc.customs.emailfrontend.utils.SpecBase
+
+class PackageSpec extends SpecBase {
+  "Utils.replaceSpaceWithEmptyString" should {
+    "replace the spaces with empty string" in new SetUp {
+      Utils.stripWhiteSpaces(stringWithOnlySpaces) mustBe emptyString
+      Utils.stripWhiteSpaces(stringWithLeadingSpaces) mustBe "abc13456"
+      Utils.stripWhiteSpaces(stringWithTrailingSpaces) mustBe "abc13456"
+      Utils.stripWhiteSpaces(stringWithSpacesWithIn_1) mustBe "abt@test.com"
+      Utils.stripWhiteSpaces(stringWithSpacesWithIn_2) mustBe "abt@test.com"
+      Utils.stripWhiteSpaces(stringWithSpacesWithIn_3) mustBe "abt@test.com"
+      Utils.stripWhiteSpaces(stringWithSpacesWithIn_4) mustBe "abt@test.com"
+    }
+  }
+}
+
+trait SetUp {
+  val singleSpace = " "
+  val emptyString = ""
+  val stringWithOnlySpaces = singleSpace * 6
+  val stringWithLeadingSpaces = "  abc13456"
+  val stringWithTrailingSpaces = "abc13456   "
+  val stringWithSpacesWithIn_1 = "abt@ test.com"
+  val stringWithSpacesWithIn_2 = "a b t@ test.com"
+  val stringWithSpacesWithIn_3 = "abt@test. com"
+  val stringWithSpacesWithIn_4 = "ab   t@   test. com"
+}

--- a/test/uk/gov/hmrc/customs/emailfrontend/forms/FormsSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/forms/FormsSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.emailfrontend.forms
+
+import uk.gov.hmrc.customs.emailfrontend.forms.Forms.emailForm
+import uk.gov.hmrc.customs.emailfrontend.model.Email
+import uk.gov.hmrc.customs.emailfrontend.utils.SpecBase
+
+class FormsSpec extends SpecBase {
+  "emailForm" must {
+    "bind the form correctly" in {
+      val mapValues_1: Map[String, String] = Map("email" -> "abc@test.com")
+      val mapValues_2: Map[String, String] = Map("email" -> "abc@te  st.com")
+      val mapValues_3: Map[String, String] = Map("email" -> "a bc@test.com")
+      val mapValues_4: Map[String, String] = Map("email" -> "    abc@test.com")
+      val mapValues_5: Map[String, String] = Map("email" -> " abc@test.com  ")
+
+      val result1 = emailForm.bind(mapValues_1)
+      val result2 = emailForm.bind(mapValues_2)
+      val result3 = emailForm.bind(mapValues_3)
+      val result4 = emailForm.bind(mapValues_4)
+      val result5 = emailForm.bind(mapValues_5)
+
+      result1.value shouldBe Option(Email("abc@test.com"))
+      result2.value shouldBe Option(Email("abc@test.com"))
+      result3.value shouldBe Option(Email("abc@test.com"))
+      result4.value shouldBe Option(Email("abc@test.com"))
+      result5.value shouldBe Option(Email("abc@test.com"))
+    }
+    "not bind when value is incorrect" in {
+
+      val mapValues_1: Map[String, String] = Map("email" -> "abctest")
+      val mapValues_2: Map[String, String] = Map("email" -> "st.com")
+      val mapValues_3: Map[String, String] = Map("email" -> "")
+      val mapValues_4: Map[String, String] = Map(
+        "email" -> "this value is more than fifty characters long hence invalid for email")
+
+      val result1 = emailForm.bind(mapValues_1)
+      val result2 = emailForm.bind(mapValues_2)
+      val result3 = emailForm.bind(mapValues_3)
+      val result4 = emailForm.bind(mapValues_4)
+
+      result1.errors.size shouldBe 1
+      result1.errors.head.message shouldBe "customs.emailfrontend.errors.valid-email.wrong-format"
+      result2.errors.size shouldBe 1
+      result2.errors.head.message shouldBe "customs.emailfrontend.errors.valid-email.wrong-format"
+      result3.errors.size shouldBe 1
+      result3.errors.head.message shouldBe "customs.emailfrontend.errors.valid-email.empty"
+      result4.errors.size shouldBe 1
+      result4.errors.head.message shouldBe "customs.emailfrontend.errors.valid-email.too-long"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/customs/emailfrontend/forms/FormsSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/forms/FormsSpec.scala
@@ -41,6 +41,7 @@ class FormsSpec extends SpecBase {
       result4.value shouldBe Option(Email("abc@test.com"))
       result5.value shouldBe Option(Email("abc@test.com"))
     }
+    
     "not bind when value is incorrect" in {
 
       val mapValues_1: Map[String, String] = Map("email" -> "abctest")

--- a/test/uk/gov/hmrc/customs/emailfrontend/forms/ValidationSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/forms/ValidationSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.emailfrontend.forms
+
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.data.validation.{Invalid, Valid, ValidationError}
+import uk.gov.hmrc.customs.emailfrontend.utils.SpecBase
+
+class ValidationSpec extends SpecBase {
+
+  "validEmail" should {
+    "return correct result" when {
+      "email is valid" in new SetUp {
+        Validation.validEmail(emailWithLeadingSpaces) mustBe Valid
+        Validation.validEmail(emailWithTrailingSpaces) mustBe Valid
+        Validation.validEmail(emailWithLeadingAndTrailingSpaces) mustBe Valid
+        Validation.validEmail(emailWithSpacesWithIn_1) mustBe Valid
+        Validation.validEmail(emailWithSpacesWithIn_2) mustBe Valid
+        Validation.validEmail(emailWithSpacesWithIn_3) mustBe Valid
+      }
+
+      "email is invalid" in new SetUp {
+        //Validation.validEmail(invalidEmail_1) mustBe Invalid  // needs to be uncommented once the regex is fixed
+        Validation.validEmail(invalidEmail_2) mustBe Invalid(
+          List(ValidationError(List("customs.emailfrontend.errors.valid-email.wrong-format"))))
+
+        Validation.validEmail(invalidEmail_3) mustBe Invalid(
+          List(ValidationError(List("customs.emailfrontend.errors.valid-email.wrong-format"))))
+
+        Validation.validEmail(invalidEmail_4) mustBe Invalid(
+          List(ValidationError(List("customs.emailfrontend.errors.valid-email.wrong-format"))))
+
+        Validation.validEmail(invalidEmail_5) mustBe Invalid(
+          List(ValidationError(List("customs.emailfrontend.errors.valid-email.too-long"))))
+      }
+    }
+  }
+}
+
+trait SetUp {
+  val spaces = "   "
+  val emailWithLeadingSpaces: String = spaces.concat("abc@test.com")
+  val emailWithTrailingSpaces: String = "abc@test.com".concat(spaces)
+  val emailWithLeadingAndTrailingSpaces: String = spaces.concat("abc@test.com").concat(spaces)
+  val emailWithSpacesWithIn_1 = "abc @test.com"
+  val emailWithSpacesWithIn_2 = "abc@ test.com"
+  val emailWithSpacesWithIn_3 = "abc@te  st.com"
+  val invalidEmail_1 = "first@last"
+  val invalidEmail_2 = "firstlast"
+  val invalidEmail_3 = "first.com"
+  val invalidEmail_4 = ".com"
+  val invalidEmail_5 = "thisemailaddressisgreaterthan50charactershenceinvalid.com"
+}


### PR DESCRIPTION
Code changes to accept the email with spaces within the email address
Below email addresses would be accepted now and email would be saved after stripping off the white spaces

Ex - abc @test.com 
       abc@ te st.com