### PR TITLE
[MMCA-4827] Removed Msg key from the email address confirmation page

### DIFF
--- a/app/uk/gov/hmrc/customs/emailfrontend/views/email_changed.scala.html
+++ b/app/uk/gov/hmrc/customs/emailfrontend/views/email_changed.scala.html
@@ -33,10 +33,4 @@
 
     @panel(newEmail = Some(newEmail))
     @p(Html(messages("customs.emailfrontend.email-confirmed.info1")))
-
-    @referrerName.map{ name =>
-        @referrerUrl.map{ url =>
-            @p(Html(messages(s"customs.emailfrontend.email-changed.redirect.info.$name", url)))
-        }
-    }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val it = project
   .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrap % Test))
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
     targetJvm := "jvm-11",

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="uk.gov.hmrc.play.logging.JsonEncoder"/>
-    </appender>
-
-    <logger name="uk.gov" level="WARN"/>
-</configuration>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,18 +14,6 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
 
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
@@ -33,15 +21,6 @@
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/EmailChangedViewSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/EmailChangedViewSpec.scala
@@ -55,4 +55,3 @@ class EmailChangedViewSpec extends SpecBase {
     val view: email_changed = app.injector.instanceOf[email_changed]
   }
 }
-

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/EmailChangedViewSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/EmailChangedViewSpec.scala
@@ -18,14 +18,12 @@ package uk.gov.hmrc.customs.emailfrontend.views
 
 import play.api.Application
 import play.api.i18n.Messages
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, stubMessages}
-import play.api.test.{FakeHeaders, FakeRequest}
 import play.twirl.api.Html
+import uk.gov.hmrc.customs.emailfrontend.utils.{FakeIdentifierAgentAction, SpecBase}
 import uk.gov.hmrc.customs.emailfrontend.views.html.email_changed
-import uk.gov.hmrc.customs.emailfrontend.utils.{SpecBase, FakeIdentifierAgentAction}
-import uk.gov.hmrc.customs.emailfrontend.controllers.routes
-import java.time.{Instant, OffsetDateTime, ZoneOffset}
-import play.api.libs.json.Json
 
 class EmailChangedViewSpec extends SpecBase {
 
@@ -35,13 +33,10 @@ class EmailChangedViewSpec extends SpecBase {
       val html: Html = view(newEmail, prevEmail, referrerName, referrerUrl)
       val content: String = contentAsString(html)
 
-      // Verify the title and headings are included
       content should include(messages("customs.emailfrontend.email-changed.title-and-heading"))
       content should include(messages("customs.emailfrontend.email-confirmed.info1"))
 
-      // Verify the new email is displayed
       content should include(newEmail)
-
     }
   }
 
@@ -52,27 +47,12 @@ class EmailChangedViewSpec extends SpecBase {
     val prevEmail: Option[String] = Some("old@example.com")
     val referrerName: Option[String] = Some("referrer")
     val referrerUrl: Option[String] = Some("/referrer")
-    val eori: String = "EORINOTIMESTAMP"
 
-    val mandatoryHeaders: Seq[(String, String)] = Seq(
-      "Date" -> OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).toString,
-      "X-Correlation-ID" -> "8b3c1eb9-7b17-49b8-a32b-b4a1566cb5d4",
-      "X-Forwarded-Host" -> "0.0.0.0",
-      "Accept" -> "application/json"
-    )
-
-    def queryParameters(eori: String): String =
-      s"?EORI=$eori&regime=CDS&acknowledgementReference=11a2b17559e64b14be257a112a7d9e8e"
-
-    implicit val request: FakeRequest[_] = FakeRequest(
-      "GET",
-      routes.EmailConfirmedController.show.url + queryParameters(eori),
-      FakeHeaders(mandatoryHeaders),
-      Json.parse("{}")
-    )
+    implicit val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequest("GET", "/some/resource/path")
 
     implicit val messages: Messages = stubMessages()
 
     val view: email_changed = app.injector.instanceOf[email_changed]
   }
 }
+

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/EmailChangedViewSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/EmailChangedViewSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.customs.emailfrontend.views
+
+import play.api.Application
+import play.api.i18n.Messages
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, stubMessages}
+import play.api.test.{FakeHeaders, FakeRequest}
+import play.twirl.api.Html
+import uk.gov.hmrc.customs.emailfrontend.views.html.email_changed
+import uk.gov.hmrc.customs.emailfrontend.utils.{SpecBase, FakeIdentifierAgentAction}
+import uk.gov.hmrc.customs.emailfrontend.controllers.routes
+import java.time.{Instant, OffsetDateTime, ZoneOffset}
+import play.api.libs.json.Json
+
+class EmailChangedViewSpec extends SpecBase {
+
+  "EmailChangedView" must {
+
+    "render the email changed page correctly" in new Setup {
+      val html: Html = view(newEmail, prevEmail, referrerName, referrerUrl)
+      val content: String = contentAsString(html)
+
+      // Verify the title and headings are included
+      content should include(messages("customs.emailfrontend.email-changed.title-and-heading"))
+      content should include(messages("customs.emailfrontend.email-confirmed.info1"))
+
+      // Verify the new email is displayed
+      content should include(newEmail)
+
+    }
+  }
+
+  trait Setup {
+    val app: Application = applicationBuilder[FakeIdentifierAgentAction]().build()
+
+    val newEmail: String = "new@example.com"
+    val prevEmail: Option[String] = Some("old@example.com")
+    val referrerName: Option[String] = Some("referrer")
+    val referrerUrl: Option[String] = Some("/referrer")
+    val eori: String = "EORINOTIMESTAMP"
+
+    val mandatoryHeaders: Seq[(String, String)] = Seq(
+      "Date" -> OffsetDateTime.ofInstant(Instant.now(), ZoneOffset.UTC).toString,
+      "X-Correlation-ID" -> "8b3c1eb9-7b17-49b8-a32b-b4a1566cb5d4",
+      "X-Forwarded-Host" -> "0.0.0.0",
+      "Accept" -> "application/json"
+    )
+
+    def queryParameters(eori: String): String =
+      s"?EORI=$eori&regime=CDS&acknowledgementReference=11a2b17559e64b14be257a112a7d9e8e"
+
+    implicit val request: FakeRequest[_] = FakeRequest(
+      "GET",
+      routes.EmailConfirmedController.show.url + queryParameters(eori),
+      FakeHeaders(mandatoryHeaders),
+      Json.parse("{}")
+    )
+
+    implicit val messages: Messages = stubMessages()
+
+    val view: email_changed = app.injector.instanceOf[email_changed]
+  }
+}


### PR DESCRIPTION
[Tasks]
- Removed unused message key
- Added missing unit test for `EmailChangedView`

[Additional]
- Fixed PlatOps errors