### PR TITLE
[MMCA- 5065] - Fix verify email journey- take user to confirmation page

### DIFF
--- a/app/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailController.scala
+++ b/app/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailController.scala
@@ -141,7 +141,10 @@ class VerifyChangeEmailController @Inject()(identify: IdentifierAction,
     emailVerificationService.createEmailVerificationRequest(
       details, routes.EmailConfirmedController.show.url, eori).flatMap {
 
-      case Some(EmailVerificationRequestSent) => Future.successful(Redirect(routes.VerifyYourEmailController.show))
+      case Some(EmailVerificationRequestSent) =>
+        save4LaterService.saveEmail(internalId, details.copy(timestamp = None)).map { _ =>
+          Redirect(routes.VerifyYourEmailController.show)
+        }
 
       case Some(EmailAlreadyVerified) =>
         save4LaterService.saveEmail(internalId, details.copy(timestamp = None)).map { _ =>

--- a/test/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailControllerSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.customs.emailfrontend.controllers
 
 import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers.eq as meq
+import org.mockito.ArgumentMatchers.{eq => meq}
 import org.scalatest.BeforeAndAfterEach
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}


### PR DESCRIPTION
Description - Fix verify email journey to take the user to the confirmation page where email is not yet verified

Below has been done as part of this PR

- [x] add test and update existing test
- [x] add code to save email for verification response 201
- [x] minor refactoring