### PR TITLE
[MMCA-5056] - remove targetJvm for Java 21 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings.{itSettings, targetJvm}
+import uk.gov.hmrc.DefaultBuildSettings.itSettings
 
 val appName = "customs-email-frontend"
 
@@ -27,7 +27,6 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
-    targetJvm := "jvm-11",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
 
     ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*filters.*;.*handlers.*;.*components.*;" +


### PR DESCRIPTION
- [x] Services will need to be on Play 2.9 or 3.0 and using sbt 1.9.7, Scala 2.13.12 to use it.
- [x] Remove targetJvm in build.sbt
- [x] Check that the service runs locally on Java 21 first.
- [x] Ensure build passes with Java 21.