### PR TITLE
[MMCA-5111] Layout Title Logic Update

### DIFF
--- a/app/uk/gov/hmrc/customs/emailfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/customs/emailfrontend/views/Layout.scala.html
@@ -28,7 +28,8 @@
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
 @import uk.gov.hmrc.customs.emailfrontend.utils.Utils.emptyString
 
-@this(appConfig: AppConfig,
+@this(
+    appConfig: AppConfig,
     hmrcStandardPage: HmrcStandardPage,
     govukBackLink: GovukBackLink,
     twoThirdsMainContent: TwoThirdsMainContent,
@@ -38,59 +39,64 @@
 )
 
 @(pageTitle: Option[String] = None,
-        backLinkUrl: Option[String] = None,
-        helpAndSupport: Boolean = true,
-        deskpro: Boolean = true,
-        startPage: Boolean = false,
-        welshToggle: Boolean = true,
-        sideBarContent: Option[Html] = None
+    backLinkUrl: Option[String] = None,
+    helpAndSupport: Boolean = true,
+    deskpro: Boolean = true,
+    startPage: Boolean = false,
+    welshToggle: Boolean = true,
+    sideBarContent: Option[Html] = None
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
+@fullPageTitle = @{
+    Some(pageTitle.map(_ + s" - ${messages("service.name")}").getOrElse(messages("service.name")))
+}
+
 @phaseBannerContent = {
-        @messages("customs.emailfrontend.phase-banner1")
-            <a class='govuk-link' href='/contact/beta-feedback-unauthenticated?service=CDS-FIN'>@messages("customs.emailfrontend.phase-banner2")</a>
-        @messages("customs.emailfrontend.phase-banner3")
-    }
+    @messages("customs.emailfrontend.phase-banner1")
+        <a class='govuk-link' href='/contact/beta-feedback-unauthenticated?service=CDS-FIN'>@messages("customs.emailfrontend.phase-banner2")</a>
+    @messages("customs.emailfrontend.phase-banner3")
+}
 
-    @additionalHead = {
-        <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css"/>
-            @hmrcTimeoutDialog(TimeoutDialog(
-            title = Some(messages("customs.emailfrontend.timeout.title")),
-            timeout = Some(appConfig.timeout),
-            countdown = Some(appConfig.countdown),
-            keepAliveUrl = Some(request.uri),
+@additionalHead = {
+    <link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css"/>
+        @hmrcTimeoutDialog(TimeoutDialog(
+        title = Some(messages("customs.emailfrontend.timeout.title")),
+        timeout = Some(appConfig.timeout),
+        countdown = Some(appConfig.countdown),
+        keepAliveUrl = Some(request.uri),
+        signOutUrl = Some(uk.gov.hmrc.customs.emailfrontend.controllers.routes.SignOutController.signOut.url),
+        timeoutUrl = Some(uk.gov.hmrc.customs.emailfrontend.controllers.routes.SignOutController.logoutNoSurvey.url)
+    ))
+}
+
+@mainContent = {
+    @contentBlock
+    @if(deskpro) {
+        <div class="govuk-!-margin-top-9">
+            @hmrcReportTechnicalIssueHelper()
+        </div>
+    }
+}
+
+@hmrcStandardPage(
+    HmrcStandardPageParams(
+        pageTitle = fullPageTitle,
+        serviceURLs =  ServiceURLs(
+            serviceUrl =  None,
             signOutUrl = Some(uk.gov.hmrc.customs.emailfrontend.controllers.routes.SignOutController.signOut.url),
-            timeoutUrl = Some(uk.gov.hmrc.customs.emailfrontend.controllers.routes.SignOutController.logoutNoSurvey.url)
-        ))
-    }
-
-    @mainContent = {
-        @contentBlock
-        @if(deskpro) {
-            <div class="govuk-!-margin-top-9">
-                @hmrcReportTechnicalIssueHelper()
-            </div>
-        }
-    }
-
-    @hmrcStandardPage(
-        HmrcStandardPageParams(
-            pageTitle = pageTitle,
-            serviceURLs =  ServiceURLs(
-                serviceUrl =  None,
-                signOutUrl = Some(uk.gov.hmrc.customs.emailfrontend.controllers.routes.SignOutController.signOut.url),
-                accessibilityStatementUrl = Some(appConfig.accessibilityLinkUrl)
-            ),
-            backLink = backLinkUrl.filter(_.nonEmpty).map(url => BackLink(href = url)),
-            templateOverrides = TemplateOverrides(
-                additionalHeadBlock = Some(additionalHead),
-                mainContentLayout = Some(sideBarContent match {
-                    case Some(value) => twoThirdsOneThirdMainContent(value)
-                    case None => twoThirdsMainContent(_)
-                })
-            ),
-            banners = Banners(
-                phaseBanner = Some(PhaseBanner(tag = Some(Tag(content = Text("BETA"))), content = HtmlContent(phaseBannerContent)))
-            ),
-            isWelshTranslationAvailable = welshToggle
-        ))(mainContent)
+            accessibilityStatementUrl = Some(appConfig.accessibilityLinkUrl)
+        ),
+        backLink = backLinkUrl.filter(_.nonEmpty).map(url => BackLink(href = url)),
+        templateOverrides = TemplateOverrides(
+            additionalHeadBlock = Some(additionalHead),
+            mainContentLayout = Some(sideBarContent match {
+                case Some(value) => twoThirdsOneThirdMainContent(value)
+                case None => twoThirdsMainContent(_)
+            })
+        ),
+        banners = Banners(
+            phaseBanner = Some(PhaseBanner(tag = Some(Tag(content = Text("BETA"))), content = HtmlContent(phaseBannerContent)))
+        ),
+        isWelshTranslationAvailable = welshToggle
+    )
+)(mainContent)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1,7 +1,7 @@
 site.error=Gwall
 site.errorPrefix=Gwall:
 
-service.name=Rheoli’ch cyfeiriad e-bost ar gyfer y Gwasanaeth Datgan Tollau (CDS)
+service.name=Gwasanaeth Datganiadau Tollau
 
 customs.emailfrontend.service-name=Rheoli’ch cyfeiriad e-bost ar gyfer y Gwasanaeth Datgan Tollau (CDS)
 customs.emailfrontend.continue-button=Yn eich blaen

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,7 +1,7 @@
 site.error=Error
 site.errorPrefix=Error:
 
-service.name=Manage your email address for CDS
+service.name=Customs Declaration Service
 
 customs.emailfrontend.service-name=Manage your email address for CDS
 customs.emailfrontend.continue-button=Continue

--- a/test/uk/gov/hmrc/customs/emailfrontend/config/ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/config/ErrorHandlerSpec.scala
@@ -58,7 +58,7 @@ class ErrorHandlerSpec extends SpecBase {
       val result: Html = errorHandler.problemWithService()(request)
       val doc          = Jsoup.parse(contentAsString(result))
 
-      doc.title shouldBe "Sorry, there is a problem with the service"
+      doc.title shouldBe "Sorry, there is a problem with the service - Customs Declaration Service"
     }
 
     "have correct text error to show 'email has not been updated' page" in {

--- a/test/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailControllerSpec.scala
@@ -390,7 +390,9 @@ class VerifyChangeEmailControllerSpec extends SpecBase with BeforeAndAfterEach {
         val doc = Jsoup.parse(contentAsString(result))
         doc.title   should not be empty
         doc.title shouldBe
-          s"${messages(app)("site.errorPrefix")} ${messages(app)("customs.emailfrontend.verify-change-email.title-and-heading")} - ${messages(app)("service.name")}"
+          s"${messages(app)("site.errorPrefix")} " +
+          s"${messages(app)("customs.emailfrontend.verify-change-email.title-and-heading")} - " +
+          s"${messages(app)("service.name")}"
       }
     }
 

--- a/test/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/controllers/VerifyChangeEmailControllerSpec.scala
@@ -390,7 +390,7 @@ class VerifyChangeEmailControllerSpec extends SpecBase with BeforeAndAfterEach {
         val doc = Jsoup.parse(contentAsString(result))
         doc.title   should not be empty
         doc.title shouldBe
-          s"${messages(app)("site.errorPrefix")} ${messages(app)("customs.emailfrontend.verify-change-email.title-and-heading")}"
+          s"${messages(app)("site.errorPrefix")} ${messages(app)("customs.emailfrontend.verify-change-email.title-and-heading")} - ${messages(app)("service.name")}"
       }
     }
 

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/ChangeYourEmailSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/ChangeYourEmailSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.customs.emailfrontend.views
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.matchers.must.Matchers.mustBe
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
@@ -53,12 +52,14 @@ class ChangeYourEmailSpec extends ViewTestHelper {
     }
   }
 
-  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString) =
-    if (title.nonEmpty) {
-      viewDoc.title() mustBe title
+  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString)(implicit messages: Messages) = {
+    val expectedTitle = if (title.nonEmpty) {
+      s"$title - ${messages("service.name")}"
     } else {
-      viewDoc.title() mustBe "Enter a new email address"
+      messages("service.name")
     }
+    viewDoc.title() should include(expectedTitle)
+  }
 
   trait Setup {
     val app: Application = applicationBuilder[FakeIdentifierAgentAction]()

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/ChangingYourEmailSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/ChangingYourEmailSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.customs.emailfrontend.views
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.matchers.must.Matchers.mustBe
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
@@ -53,12 +52,14 @@ class ChangingYourEmailSpec extends ViewTestHelper {
     }
   }
 
-  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString) =
-    if (title.nonEmpty) {
-      viewDoc.title() mustBe title
+  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString)(implicit messages: Messages) = {
+    val expectedTitle = if (title.nonEmpty) {
+      s"$title - ${messages("service.name")}"
     } else {
-      viewDoc.title() mustBe "Changing your email address for the Customs Declaration Service"
+      messages("service.name")
     }
+    viewDoc.title() should include(expectedTitle)
+  }
 
   trait Setup {
     val app: Application = applicationBuilder[FakeIdentifierAgentAction]()

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/CheckYourEmailSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/CheckYourEmailSpec.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.customs.emailfrontend.views
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.scalatest.matchers.must.Matchers.mustBe
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
@@ -53,12 +52,14 @@ class CheckYourEmailSpec extends ViewTestHelper {
     }
   }
 
-  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString) =
-    if (title.nonEmpty) {
-      viewDoc.title() mustBe title
+  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString)(implicit messages: Messages) = {
+    val expectedTitle = if (title.nonEmpty) {
+      s"$title - ${messages("service.name")}"
     } else {
-      viewDoc.title() mustBe "Check your email address"
+      messages("service.name")
     }
+    viewDoc.title() should include(expectedTitle)
+  }
 
   trait Setup {
     val app: Application = applicationBuilder[FakeIdentifierAgentAction]()

--- a/test/uk/gov/hmrc/customs/emailfrontend/views/LayoutSpec.scala
+++ b/test/uk/gov/hmrc/customs/emailfrontend/views/LayoutSpec.scala
@@ -59,12 +59,14 @@ class LayoutSpec extends SpecBase {
     }
   }
 
-  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString) =
-    if (title.nonEmpty) {
-      viewDoc.title() mustBe title
+  private def shouldContainCorrectTitle(viewDoc: Document, title: String = emptyString)(implicit messages: Messages) = {
+    val expectedTitle = if (title.nonEmpty) {
+      s"$title - ${messages("service.name")}"
     } else {
-      viewDoc.title() mustBe "GOV.UK - The best place to find government services and information"
+      messages("service.name")
     }
+    viewDoc.title() mustBe expectedTitle
+  }
 
   private def shouldContainCorrectServiceUrls(viewDoc: String) = {
     viewDoc.contains(uk.gov.hmrc.customs.emailfrontend.controllers.routes.SignOutController.signOut.url) mustBe true


### PR DESCRIPTION
[Tasks]
* Updated `Layout` template to ensure service.name is consistently appended to the page title
* Fixed failing tests in:
    * `LayoutSpec`
    * `VerifyChangeEmailControllerSpec`
    *  `ChangeYourEmailSpec`
    * `CheckYourEmailSpec`
    * `ChangingYourEmailSpec`




