### PR TITLE
[MMCA-5156] Updated scala version to 3.3.4 and fixed warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import uk.gov.hmrc.DefaultBuildSettings.itSettings
 val appName = "customs-email-frontend"
 
 val silencerVersion = "1.7.16"
-val scala3_3_3 = "3.3.3"
+val scala3_3_4 = "3.3.4"
 val bootstrap = "9.1.0"
 
 val scalaStyleConfigFile = "scalastyle-config.xml"
@@ -12,7 +12,7 @@ val testScalaStyleConfigFile = "test-scalastyle-config.xml"
 val testDirectory = "test"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := scala3_3_3
+ThisBuild / scalaVersion := scala3_3_4
 
 lazy val scalastyleSettings = Seq(scalastyleConfig := baseDirectory.value / scalaStyleConfigFile,
   (Test / scalastyleConfig) := baseDirectory.value / testDirectory / testScalaStyleConfigFile)
@@ -38,7 +38,7 @@ lazy val microservice = Project(appName, file("."))
     ScoverageKeys.coverageFailOnMinimum := false,
     ScoverageKeys.coverageHighlighting := true,
 
-    scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")),
+    scalacOptions := scalacOptions.value.diff(Seq("-Wunused:all")) ++ Seq("-Wconf:msg=Flag.*repeatedly:s"),
     Test / scalacOptions ++= Seq(
       "-Wunused:imports",
       "-Wunused:params",

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val microservice = Project(appName, file("."))
     ),
     scalafmtDetailedError := true,
     scalafmtPrintDiff := true,
-    scalafmtFailOnErrors := true
+    scalafmtFailOnErrors := true,
   )
   .settings(PlayKeys.playDefaultPort := 9898)
   .settings(resolvers += Resolver.jcenterRepo)

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 import scoverage.ScoverageKeys
 import uk.gov.hmrc.DefaultBuildSettings.itSettings
+import AppDependencies.bootstrapVersion
 
 val appName = "customs-email-frontend"
 
 val silencerVersion = "1.7.16"
 val scala3_3_4 = "3.3.4"
-val bootstrap = "9.1.0"
 
 val scalaStyleConfigFile = "scalastyle-config.xml"
 val testScalaStyleConfigFile = "test-scalastyle-config.xml"
@@ -21,7 +21,7 @@ lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")
   .settings(itSettings())
-  .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrap % Test))
+  .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test))
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
@@ -58,7 +58,7 @@ lazy val microservice = Project(appName, file("."))
     ),
     scalafmtDetailedError := true,
     scalafmtPrintDiff := true,
-    scalafmtFailOnErrors := true,
+    scalafmtFailOnErrors := true
   )
   .settings(PlayKeys.playDefaultPort := 9898)
   .settings(resolvers += Resolver.jcenterRepo)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,13 +2,13 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.1.0"
+  private val bootstrapVersion = "9.8.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc"                  %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"                  %% "play-frontend-hmrc-play-30" % "10.5.0",
-    "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-30"         % "2.2.0",
+    "uk.gov.hmrc"                  %% "play-frontend-hmrc-play-30" % "11.11.0",
+    "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-30"         % "2.4.0",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.17.0",
     "org.typelevel"                %% "cats-core"                  % "2.10.0"
   )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,9 +4,11 @@ object AppDependencies {
 
   private val bootstrapVersion = "9.8.0"
 
+  private val excludeHttpVerbs = ExclusionRule(organization = "uk.gov.hmrc", name = "http-verbs-play-30")
+
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-30" % bootstrapVersion,
+    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-30" % bootstrapVersion excludeAll excludeHttpVerbs,
     "uk.gov.hmrc"                  %% "play-frontend-hmrc-play-30" % "11.11.0",
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-30"         % "2.4.0",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.17.0",
@@ -14,7 +16,7 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-test-play-30" % bootstrapVersion % Test,
+    "uk.gov.hmrc"       %% "bootstrap-test-play-30" % bootstrapVersion % Test excludeAll excludeHttpVerbs,
     "org.jsoup"          % "jsoup"                  % "1.17.2"         % Test,
     "org.scalatestplus" %% "mockito-4-11"           % "3.2.18.0"       % Test
   )

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.8.0"
+  val bootstrapVersion = "9.8.0"
 
   private val excludeHttpVerbs = ExclusionRule(organization = "uk.gov.hmrc", name = "http-verbs-play-30")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
-addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
+addSbtPlugin("com.github.sbt" % "sbt-gzip" % "2.0.0")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 


### PR DESCRIPTION
[Tasks]
- Updated to scala `3.3.4`
- Suppressed `.repeatedly` warnings by adding the appropriate compiler flag
- Updated dependencies for compatibility and stability